### PR TITLE
adapt code to GCC 9.4.0

### DIFF
--- a/Generator/source/CMakeLists.txt
+++ b/Generator/source/CMakeLists.txt
@@ -98,6 +98,15 @@ add_subdirectory(DataBase)
 target_link_libraries(prog TruthTable Reliability GraphVertex OrientedGraph Circuit AuxiliaryMethods FilesTools settings OptimizationUtils ThreadPool DataBaseGenerator nlohmann_json::nlohmann_json)
 add_subdirectory(tests)
 
+# Check if pthreads is installed; adjust compiler/linker options
+find_package(Threads REQUIRED)
+if(THREADS_HAVE_PTHREAD_ARG)
+  target_compile_options(prog PUBLIC "-lpthread")
+endif()
+if(CMAKE_THREAD_LIBS_INIT)
+  target_link_libraries(prog "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+
 target_include_directories(settings PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(FilesTools PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(AuxiliaryMethods PUBLIC ${CMAKE_SOURCE_DIR})

--- a/Generator/source/DataBase/DataBaseGenerator.cpp
+++ b/Generator/source/DataBase/DataBaseGenerator.cpp
@@ -219,7 +219,7 @@ void DataBaseGenerator::GenerateDataBaseComparison(const GenerationParameters &i
     bool compare0 = i_param.getComparison().compare0;
     bool compare1 = i_param.getComparison().compare1;
     bool compare2 = i_param.getComparison().compare2;
-    OrientedGraph graph = sg.generatorСomparison(bits, compare0, compare1, compare2);
+    OrientedGraph graph = sg.generatorComparison(bits, compare0, compare1, compare2);
     Circuit c(graph);
     c.setPath(d_mainPath);
     c.setCircuitName(i_param.getName());

--- a/Generator/source/generators/SimpleGenerators.cpp
+++ b/Generator/source/generators/SimpleGenerators.cpp
@@ -454,7 +454,7 @@ OrientedGraph SimpleGenerators::generatorSummator(int bits, bool overflowIn, boo
     return graph;
 }
 
-OrientedGraph SimpleGenerators::generatorСomparison(int bits, bool compare0, bool compare1, bool compare2, bool act)
+OrientedGraph SimpleGenerators::generatorComparison(int bits, bool compare0, bool compare1, bool compare2, bool act)
 {
     OrientedGraph graph;
 

--- a/Generator/source/generators/SimpleGenerators.h
+++ b/Generator/source/generators/SimpleGenerators.h
@@ -19,7 +19,7 @@ public:
         std::map<std::string, int> i_logicOper,
         bool i_leaveEmptyOut = true);
     OrientedGraph generatorSummator(int bits, bool overflowIn, bool overflowOut, bool minus, bool act = false);
-    OrientedGraph generatorСomparison(int bits, bool compare0, bool compare1, bool compare2, bool act = false);
+    OrientedGraph generatorComparison(int bits, bool compare0, bool compare1, bool compare2, bool act = false);
     OrientedGraph generatorEncoder(int bits);
 
     void setGatesInputsInfo(const std::map<std::string, std::vector<int>> &i_info) {


### PR DESCRIPTION
For Ubuntu 20.04 x86_64 and it's default GCC 9.4.0 several problems prevent generator to be built. 

They are:
- Cyrillic and Latin letters in function names;
- linker issue with pthread library ("undefined reference" error).

The commit solves these problems.